### PR TITLE
Liveupdating subsets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,14 +48,15 @@ assert.equal(archivedTasks.length, 1);
 
 ## Live Updating of subsets
 
-By default subsets will be updated live. That is, if a models attributes
+Subsets can be optionally updated live. That is, if a models attributes
 change such that affect it's membership of a subset, that update will
 happen automatically.
 
-Continuing the above example:
+By default live updating is disabled. Continuing the above example:
 
 ```
 tasks.reset([{archived: true}, {archived: false}]);
+archivedTasks.liveupdate_keys = 'all'
 
 assert.equal(tasks.length, 2);
 assert.equal(archivedTasks.length, 1);
@@ -69,10 +70,11 @@ assert.equal(archivedTasks.length, 0);
 
 Live updating is controlled by a subset's `liveupdate\_keys` attribute.
 
-To prevent live updating of a subset, set it's `liveupdate\_keys` attribute
-to be 'none'.
-
-To limit which model keys trigger a live update, set `liveupdate\_keys`
+* To prevent live updating of a subset, set it's `liveupdate\_keys` attribute
+to be 'none' (this is the default).
+* To enable live updating when any model key changes, set
+  `liveupdate\_keys = 'all'`.
+* To limit which model keys trigger a live update, set `liveupdate\_keys`
 to be an array of attributes: `liveupdate\_keys = ['archived']`.
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -42,9 +42,39 @@ archivedTasks = new Collections.ArchivedTasks();
 
 tasks.reset([{archived: true}, {archived: false}]);
 
-assert.equal(task.length, 2);
+assert.equal(tasks.length, 2);
 assert.equal(archivedTasks.length, 1);
 ```
+
+## Live Updating of subsets
+
+By default subsets will be updated live. That is, if a models attributes
+change such that affect it's membership of a subset, that update will
+happen automatically.
+
+Continuing the above example:
+
+```
+tasks.reset([{archived: true}, {archived: false}]);
+
+assert.equal(tasks.length, 2);
+assert.equal(archivedTasks.length, 1);
+
+tasks.first().set({archived: false});
+assert.equal(tasks.length, 2);
+assert.equal(archivedTasks.length, 0);
+```
+
+### Controlling live updating
+
+Live updating is controlled by a subset's `liveupdate\_keys` attribute.
+
+To prevent live updating of a subset, set it's `liveupdate\_keys` attribute
+to be 'none'.
+
+To limit which model keys trigger a live update, set `liveupdate\_keys`
+to be an array of attributes: `liveupdate\_keys = ['archived']`.
+
 
 ## Tests
 

--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -25,7 +25,7 @@
 
     this.model = this.parent().model;
     this.comparator = this.comparator || options.comparator || this.parent().comparator;
-    this.liveupdate_keys = options.liveupdate_keys || 'all';
+    this.liveupdate_keys = this.liveupdate_keys || options.liveupdate_keys || 'none';
 
     _.bindAll(this, '_onModelEvent', '_unbindModelEvents', '_proxyEvents');
 

--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -25,6 +25,7 @@
 
     this.model = this.parent().model;
     this.comparator = this.comparator || options.comparator || this.parent().comparator;
+    this.liveupdate_keys = options.liveupdate_keys || 'all';
 
     _.bindAll(this, '_onModelEvent', '_unbindModelEvents', '_proxyEvents');
 
@@ -161,17 +162,40 @@
    * @return {Object} model
    */
   Subset._proxyEvents = function (ev, model, collection, options) {
-    if (ev === 'add' && collection !== this && this.sieve(model) && !options.noproxy) {
-      this._addToSubset(model, options);
-    }
+    if ( collection !== this) {
+      if (ev === 'change' && this.liveupdate_keys === 'all') {
+        this._updateModelMembership(model);
+      } else if (ev.slice(0,7) == 'change:' && _.isArray(this.liveupdate_keys) && _.include(this.liveupdate_keys, ev.slice(7))) {
+        this._updateModelMembership(model);
+      }
 
-    if (ev === 'remove' && collection !== this && this.sieve(model) && !options.noproxy) {
-      this._removeFromSubset(model, options);
-    }
+      if (ev === 'add' && this.sieve(model) && !options.noproxy) {
+        this._addToSubset(model, options);
+      }
+
+      if (ev === 'remove' && this.sieve(model) && !options.noproxy) {
+        this._removeFromSubset(model, options);
+      }
+    } 
 
     // model == collection
     if (ev === 'reset' && model !== this && model.any(this.sieve)) {
       this._resetSubset(model.models, collection);
+    }
+  };
+
+  /**
+   * Determines whether a model should be in the subset, and adds or removes it
+   * @param {Object} model
+   */
+  Subset._updateModelMembership = function(model) {
+    var hasId = model.id != null;
+    var alreadyInSubset = this._byCid[model.cid] || (hasId && this._byId[model.id]);
+
+    if (this.sieve(model)) {
+      !alreadyInSubset && this._addToSubset(model);
+    } else {
+      alreadyInSubset && this._removeFromSubset(model);
     }
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -202,3 +202,83 @@ describe('Aggregated collections', function () {
     assert.deepEqual(_.pluck(archived_tasks.models, 'cid'), ['c11', 'c10']);
   });
 });
+
+describe('Live updating subset membership', function() {
+  it('removes a model from the subset if the model\'s attributes change such that it\'s no longer part of the set', function() {
+    tasks = new Collections.Tasks();
+    archived_tasks = new Collections.ArchivedTasks();
+
+    tasks.reset([{id: 0, archived: 0}, {id: 1, archived: 1}, {id: 2, archived: 1}]);
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+
+    //Update 1 so that it's not in the archived set
+    tasks.get(1).set({archived: 0});
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 1);
+  });
+  
+  it('adds a model to the set if the model\'s attributes change such that it should now be sieved into the set', function() {
+    tasks = new Collections.Tasks();
+    archived_tasks = new Collections.ArchivedTasks();
+
+    tasks.reset([{id: 0, archived: 0}, {id: 1, archived: 1}, {id: 2, archived: 1}]);
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+
+    //Update 0 so that it should be in the archived set
+    tasks.get(0).set({archived: 1});
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 3);
+  });
+  
+  it('adds a model to the set if the model\'s attributes change such that it should now be sieved into the set', function() {
+    tasks = new Collections.Tasks();
+    archived_tasks = new Collections.ArchivedTasks();
+
+    tasks.reset([{id: 0, archived: 0}, {id: 1, archived: 1}, {id: 2, archived: 1}]);
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+
+    //Update 0 so that it should be in the archived set
+    tasks.get(0).set({archived: 1});
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 3);
+  });
+  
+  it('won\'t update a subset\'s members if a key changes that is not listed in liveupdate_keys', function() {
+    tasks = new Collections.Tasks();
+    archived_tasks = new Collections.ArchivedTasks(null, {liveupdate_keys: ['order']});
+
+    tasks.reset([{id: 0, archived: 0, order: 0}, {id: 1, archived: 1, order: 1}, {id: 2, archived: 1, order: 2}]);
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+
+    //Update 0 so that it should be in the archived set, but our set won't update because it updates on 'change:order'
+    tasks.get(0).set({archived: 1});
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+
+    tasks.get(1).set({archived: 1});
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+  });
+
+  it('will update a subset\'s members if a key changes that is listed in liveupdate_keys', function() {
+    tasks = new Collections.Tasks();
+    archived_tasks = new Collections.ArchivedTasks(null, {liveupdate_keys: ['archived']});
+
+    tasks.reset([{id: 0, archived: 0, order: 0}, {id: 1, archived: 1, order: 1}, {id: 2, archived: 1, order: 2}]);
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+
+    //Update 0 so that it should be in the archived set, but our set won't update because it updates on 'change:order'
+    tasks.get(0).set({archived: 1});
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 3);
+
+    tasks.get(1).set({archived: 0});
+    assert.equal(tasks.length, 3);
+    assert.equal(archived_tasks.length, 2);
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -206,7 +206,7 @@ describe('Aggregated collections', function () {
 describe('Live updating subset membership', function() {
   it('removes a model from the subset if the model\'s attributes change such that it\'s no longer part of the set', function() {
     tasks = new Collections.Tasks();
-    archived_tasks = new Collections.ArchivedTasks();
+    archived_tasks = new Collections.ArchivedTasks(null, {liveupdate_keys: 'all'});
 
     tasks.reset([{id: 0, archived: 0}, {id: 1, archived: 1}, {id: 2, archived: 1}]);
     assert.equal(tasks.length, 3);
@@ -220,7 +220,7 @@ describe('Live updating subset membership', function() {
   
   it('adds a model to the set if the model\'s attributes change such that it should now be sieved into the set', function() {
     tasks = new Collections.Tasks();
-    archived_tasks = new Collections.ArchivedTasks();
+    archived_tasks = new Collections.ArchivedTasks(null, {liveupdate_keys: 'all'});
 
     tasks.reset([{id: 0, archived: 0}, {id: 1, archived: 1}, {id: 2, archived: 1}]);
     assert.equal(tasks.length, 3);
@@ -234,7 +234,7 @@ describe('Live updating subset membership', function() {
   
   it('adds a model to the set if the model\'s attributes change such that it should now be sieved into the set', function() {
     tasks = new Collections.Tasks();
-    archived_tasks = new Collections.ArchivedTasks();
+    archived_tasks = new Collections.ArchivedTasks(null, {liveupdate_keys: 'all'});
 
     tasks.reset([{id: 0, archived: 0}, {id: 1, archived: 1}, {id: 2, archived: 1}]);
     assert.equal(tasks.length, 3);


### PR DESCRIPTION
Hi guys.

I found subset last night, and it's looking pretty awesome. For my use however, I wanted subsets to be automatically updated if a model's attributes change. i.e: 

```
tasks.reset([{archived: true}, {archived: false}]);

assert.equal(tasks.length, 2);
assert.equal(archivedTasks.length, 1);

tasks.first().set({archived: false});
assert.equal(tasks.length, 2);
assert.equal(archivedTasks.length, 0);
```

This makes it really easy to keep my views in sync with any changes made to models by the user/app. So here's a patch that does just that.

I've added a `liveupdate_keys` attribute to the subset. If set to `'all'`, the subsets will be updated on all model changes. If set to an array of attributes (`liveupdate_keys = ['archived']`), the subset will only be updated when those keys change. If set to `'none'` or `''` the subset will not be live updated.
### Before merging, I'd love some discussion/feedback on:
- is this a good idea?
- should liveupdating be the default behaviour (currently `liveupdate_keys` defaults to `'all'` in my branch).
- is `liveupdate_keys` an appropriate name for the property

Thanks!
Phil
