### PR TITLE
Update for backbone 0.9.0 support.

### DIFF
--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -50,12 +50,12 @@
 
     // delete parent reseted models
     this.each(function (model) {
-      this.parent()._remove(model, _.extend(options, {noproxy: true}));
+      this.parent().remove(model, _.extend(options, {noproxy: true}));
     }, this);
 
     // insert parent reseted models
     _.each(models, function (model) {
-      this.parent()._add(model, _.extend(options, {noproxy: true}));
+      this.parent().add(model, _.extend(options, {noproxy: true}));
     }, this);
 
     return this._resetSubset(models, options);
@@ -95,8 +95,8 @@
    * @param {Object} options
    * @return {Object} model
    */
-  Subset._add = function (model, options) {
-    return this.parent()._add(model, options);
+  Subset.add = function (model, options) {
+    return this.parent().add(model, options);
   };
 
   /**
@@ -107,7 +107,7 @@
    * @return {Object} model
    */
   Subset._addToSubset = function (model, options) {
-    return Backbone.Collection.prototype._add.call(this, model, options);
+    return Backbone.Collection.prototype.add.call(this, model, options);
   }
 
   /**
@@ -117,8 +117,8 @@
    * @param {Object} options
    * @return {Object} model
    */
-  Subset._remove = function (model, options) {
-    return this.parent()._remove(model, options);
+  Subset.remove = function (model, options) {
+    return this.parent().remove(model, options);
   };
 
   /**
@@ -129,7 +129,7 @@
    * @return {Object} model
    */
   Subset._removeFromSubset = function (model, options) {
-    return Backbone.Collection.prototype._remove.call(this, model, options);
+    return Backbone.Collection.prototype.remove.call(this, model, options);
   }
 
   /**


### PR DESCRIPTION
The only thing that seems to be needed is to rename all references to `collection._add` and `collection._remove` to `collection.add` and `collection.remove` since Backbone was refactored to remove `_add` and `_remove`.

The tests all pass, however I am a little concerned that all the tests pass even when I use Backbone v0.5.3. Does anyone know the rationale behind using `_add` instead of `add` in the first place?

As far as I can tell, using `_add` in Backbone 0.5.3 bypassed sorting of the collection, and triggering of `add` events on the models being added. Not sure if that's going to cause issues.
