### PR TITLE
Allow setting parent for each instance of the subset collection. fixes #4

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -51,10 +51,7 @@ Collections.ArchivedTasks = Backbone.Subset.extend({
 });
 
 Collections.UrgentTasks = Backbone.Subset.extend({
-  parent: function () {
-    return tasks;
-  }
-, sieve: function (task) {
+  sieve: function (task) {
     return task.isUrgent();
   }
 , comparator: function (m) {
@@ -85,7 +82,7 @@ Collections.ProjectTasks = Backbone.Subset.extend({
 
 tasks = new Collections.Tasks();
 archived_tasks = new Collections.ArchivedTasks();
-urgent_tasks = new Collections.UrgentTasks();
+urgent_tasks = new Collections.UrgentTasks([], {parent: tasks});
 
 
 // lengths


### PR DESCRIPTION
e.g.  new Collections.UrgentTasks([], {parent: tasks});

This will override the #parent method defined on the class (if any)
or fallback to it if no parent option is supplied to the constructor.

Prompted by discussion here: https://github.com/masylum/Backbone.Subset/issues/4
