### PR TITLE
Subset.recalculate was stopping after the first change was applied.

### DIFF
--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -115,7 +115,7 @@
 
     // re-evaluate each model's eligibility
     changed = _.result(this, 'parent').reduce(function (changed, model) {
-      return changed || self._updateModelMembership(model, {silent: true});
+      return self._updateModelMembership(model, {silent: true}) || changed;
     }, false);
 
     // only trigger reset event if the subset actually changed


### PR DESCRIPTION
If changed == false _updateModelMembership was not being called at all and the remaining elements were unaffected. Changing the order fixed the problem for me.
