### PR TITLE
Compatibility with Backbone 0.9.10 (fixes #9)

### DIFF
--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -55,6 +55,8 @@
       this.beforeInitialize.apply(this, arguments);
     }
 
+    this.models = [];
+
     if (!options.no_reset) {
       this._reset();
       this.reset(models || parent.models, {silent: true});
@@ -330,8 +332,7 @@
    * @return {Boolean} changed
    */
   Subset._updateModelMembership = function (model, options) {
-    var hasId = !model.id
-      , alreadyInSubset = this._byCid[model.cid] || (hasId && this._byId[model.id]);
+    var alreadyInSubset = !_.isUndefined(this.get(model));
 
     if (this.sieve(model)) {
       if (!alreadyInSubset) {


### PR DESCRIPTION
There were two additional problems besides the one in issue #9 :
- `this._byCid` does not exist anymore in 0.9.10
- `!model.id` breaks with a numeric id set to `0`

Using the `get` method here is much cleaner as it is guaranteed to abstract between the different versions of Backbone. Besides, not depending on private interfaces is always good :wink: 

As @Crisfole said, `this.models` was not initialized properly.

The test suite now passes with both Backbone 0.9.10 and 0.5.3.
