### PR TITLE
Exclusive Subsets

### DIFF
--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -84,8 +84,7 @@
    * @return {Object}
    */
   Subset._isExclusive = function() {
-    var check = this.exclusiveSubset;
-    return _.isFunction(check) ? check() : check
+   return  _.result(this, 'exclusiveSubset')
   };
 
   /**

--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -74,7 +74,7 @@
    */
   Subset._asExclusive = function(options) {
     var options = options || {};
-    options.exclusive_collection = true;
+    options.exclusive_collection = this;
     return options
   };
 

--- a/backbone.subset.js
+++ b/backbone.subset.js
@@ -65,13 +65,27 @@
     this.initialize.apply(this, arguments);
   };
 
+  Subset.exclusiveSubset = false
+
   /**
-   * Default exclusiveSubset implementation
+   * Updates options to work with exclusive subsets
    *
-   * @return {Boolean}
+   * @return {Object}
    */
-  Subset.exclusiveSubset = function () {
-    return false;
+  Subset._asExclusive = function(options) {
+    var options = options || {};
+    options.exclusive_collection = true;
+    return options
+  };
+
+  /**
+   * Inspector to check if this is an exclusive subset
+   *
+   * @return {Object}
+   */
+  Subset._isExclusive = function() {
+    var check = this.exclusiveSubset;
+    return _.isFunction(check) ? check() : check
   };
 
   /**
@@ -105,7 +119,7 @@
     xored_ids = xor(ids, _.pluck(models, 'id'));
 
     parent.reset(parent_models, _.extend({silent: true}, options));
-    if (this.exclusiveSubset()) {
+    if (this._isExclusive()) {
       parent.trigger('reset', this, _.extend({model_ids: xored_ids, exclusive_collection: this}, options));
     } else {
       parent.trigger('reset', this, _.extend({model_ids: xored_ids}, options));
@@ -170,8 +184,8 @@
    * @return {Object} model
    */
   Subset.add = function (model, options) {
-    if (this.exclusiveSubset()) {
-      options = _.extend(options, {exclusive_collection: this});
+    if (this._isExclusive()) {
+      options = this._asExclusive(options);
     }
 
     return _.result(this, 'parent').add(model, options);
@@ -198,8 +212,8 @@
    * @return {Object} model
    */
   Subset.remove = function (model, options) {
-    if (this.exclusiveSubset()) {
-      options = _.extend(options, {exclusive_collection: this});
+    if (this._isExclusive()) {
+      options = this._asExclusive(options);
     }
 
     return _.result(this, 'parent').remove(model, options);


### PR DESCRIPTION
Hey,

I ran into an issue with exclusive subsets; because, I wasn't sending options when adding/removing models. So when the code went to extend the options with {exclusive_collection: true} it would crash.

This code checks for undefined options. It also let's you define this.exclusive_collection as a Boolean instead of having to pass a function. Function still works, but now it's just a little less code to use.

Thanks for the awesome lib! Saved me a ton of work.
- Jordan
